### PR TITLE
Fix #23 decrease horizontal width of badges

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -23,7 +23,7 @@ class RepositoriesController < ApplicationController
     response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
     response.headers["Pragma"] = "no-cache"
     if variant
-      redirect_to @report.badge_url(variant, style)
+      redirect_to @report.badge_url(variant, style, option)
     else
       not_found_badge
     end
@@ -58,6 +58,10 @@ class RepositoriesController < ApplicationController
     _variant = params[:variant].to_s
     return nil unless ['pr','issue'].include?(_variant)
     _variant
+  end
+
+  def option
+    params[:concise] || false
   end
 
   def not_found_badge


### PR DESCRIPTION
This pull request provides greater conciseness of badge text, as per the #23 enhancement request.  Several formats were proposed there, one was chosen for implementation.

All permutations of Issue badge text in the pull request:

[issue closure | < 1 min]
[issue closure | 23 min]
[issue closure | ~1 hr]
[issue closure | 9 hrs]
[issue closure | 1 day]
[issue closure | 23 days]
[issue closure | ~1 mon]
[issue closure | 10 mon]
[issue closure | > 2 yrs]

The two entries with the ~ sign map to the 'about' in the previous badge, but I actually question the utility of it -- their presence in the original (current) badges being a side-effect of using the ``distance_of_time_in_words()`` Ruby function.

I would actually prefer to consolidate these a bit, and resubmit this pull, if you agree.  Here is what I think is simpler, yet equally meaningful to users:

[issue closure | X min]
[issue closure | X hrs]
[issue closure | X days]
[issue closure | X mon]
[issue closure | X yrs]

The variant for *hours*, *days*, and *years* would account for singular and plural forms (eg. 1 hr, 2 hrs).
