### PR TITLE
Use renamed nodejs/node repo in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ http://issuestats.com/github/twbs/bootstrap/badge/issue :
 
 You can add `?style=flat` to the url to get a flat badge:
 
-http://issuestats.com/github/joyent/node/badge/pr?style=flat :
-![joyent/node](http://issuestats.com/github/joyent/node/badge/pr?style=flat)
+http://issuestats.com/github/nodejs/node/badge/pr?style=flat :
+![nodejs/node](http://issuestats.com/github/nodejs/node/badge/pr?style=flat)
 
 `?style=flat-square` is also available:
 
-http://issuestats.com/github/joyent/node/badge/pr?style=flat-square :
-![joyent/node](http://issuestats.com/github/joyent/node/badge/pr?style=flat-square)
+http://issuestats.com/github/nodejs/node/badge/pr?style=flat-square :
+![nodejs/node](http://issuestats.com/github/nodejs/node/badge/pr?style=flat-square)
 
 You can also add `?concise=true` to the URL to get a more concise version: (thanks to [brettwooldridge](https://github.com/brettwooldridge)):
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ http://issuestats.com/github/nodejs/node/badge/pr?style=flat-square :
 You can also add `?concise=true` to the URL to get a more concise version: (thanks to [brettwooldridge](https://github.com/brettwooldridge)):
 
 http://issuestats.com/github/rails/rails/badge/pr?style=flat-square&concise=true :
-![joyent/node](http://issuestats.com/github/joyent/node/badge/pr?style=flat-square&concise=true)
+![rails/rails](http://issuestats.com/github/rails/rails/badge/pr?style=flat-square&concise=true)
 
 ## API
 

--- a/app/views/layouts/_welcome.html.haml
+++ b/app/views/layouts/_welcome.html.haml
@@ -19,7 +19,7 @@
     %br
     %br
     .row
-      - ["rails/rails", "joyent/node", "twbs/bootstrap"].each do |github_key|
+      - ["rails/rails", "nodejs/node", "twbs/bootstrap"].each do |github_key|
         - split = github_key.split("/")
         - opts = {owner: split[0], repository: split[1]}
         .col-lg-4


### PR DESCRIPTION
Since joyent/node has come and gone, renamed the repository references to joyent/node to nodejs/node.

Additionally, the README had an example for rails/rails, but it was using joyent/node, so I swapped that to rails/rails.