### PR TITLE
Added ability to use full GitHub URL in search

### DIFF
--- a/app/assets/javascripts/repositories.js.coffee
+++ b/app/assets/javascripts/repositories.js.coffee
@@ -19,6 +19,9 @@
 $ ->
   $('#search').submit ->
     val = $('#search-input').val()
+    # Remove any GitHub URL prefix from the target
+    # e.g. https://github.com/rails/rails -> rails/rails
+    val = val.replace(/^https?:\/\/github.com\//, '')
     document.location = "/github/#{val}"
     false
 


### PR DESCRIPTION
As initially proposed in #15, we want the ability to paste full GitHub URLs into the search box. This is to make it easier when searching for an application (e.g. instead of clicking/dragging exactly for the name, we can select the address bar in two clicks).

In this PR:

- Updated `#search.submit` Coffeescript to coerce `https://github.com/org/repo` to `org/repo`
    - For example, `https://github.com/hstove/issue_stats` -> `hstove/issue_stats`
- Fixes #15 

**Missing:**

I wanted to write a test for this but I didn't see anything testing search form submission via `git grep -i` =/